### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 - **Real device testing** catches iOS-specific bugs that simulators miss.
 - Works with **Claude Code, VS Code, Cursor, Windsurf, Codex CLI, Antigravity, JetBrains**, and any MCP-compatible client.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/nnemirovsky-iwdp-mcp).
+
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/nnemirovsky-iwdp-mcp)